### PR TITLE
Add mcp-hub to Development Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Public test endpoints:
 - [taskade/mcp](https://github.com/taskade/mcp/tree/main/packages/openapi-codegen) 📇 - Generate MCP tools from OpenAPI schemas. Supports auto-linking, response normalization, and MCP server integration.
 - [type-mcp/mcp-anything](https://github.com/type-mcp/mcp-anything) 🐍 - Auto-generates MCP servers from any codebase or API spec (FastAPI, Flask, Spring Boot, Express, Go, Rails, OpenAPI, GraphQL, gRPC) in one command.
 - [Writbase/writbase](https://github.com/Writbase/writbase) 📇 - MCP-native task management system for AI agent fleets with multi-agent permissions and inter-agent delegation.
+- [mcp-hub](https://github.com/jiale-cheng-ning/mcp-hub) 🦀 🏠 🍎 🪟 🐧 - TUI dashboard for managing, monitoring, and auditing MCP server configurations across Claude Desktop, Cursor, VS Code, and Windsurf. Auto-discovers configs, runs security audits (plaintext secrets, dangerous permissions, unpinned packages), and health checks.
 
 ## Hosting
 


### PR DESCRIPTION
## What

Add [mcp-hub](https://github.com/jiale-cheng-ning/mcp-hub) to the Development Tools section.

## Why

mcp-hub solves a real pain point: developers install MCP servers across Claude Desktop, Cursor, VS Code, and Claude Code, but configs are scattered in different JSON files with no unified way to see, audit, or monitor them.

**Key features:**
- Auto-discovers MCP configs from all major clients
- Security audit — detects plaintext secrets, dangerous filesystem permissions, unpinned package versions, duplicate servers
- Health checks — shows which servers are running vs down
- Interactive TUI dashboard — terminal-based server browser with detail panel

Built with ratatui + crossterm. Single Rust binary, no runtime dependencies. MIT licensed.

## Entry added

```markdown
- [mcp-hub](https://github.com/jiale-cheng-ning/mcp-hub) 🦀 🏠 🍎 🪟 🐧 - TUI dashboard for managing, monitoring, and auditing MCP server configurations across Claude Desktop, Cursor, VS Code, and Windsurf. Auto-discovers configs, runs security audits (plaintext secrets, dangerous permissions, unpinned packages), and health checks.
```