### PR TITLE
feat: add NotFair open-source Claude Code skills for SEO and paid ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Public test endpoints:
 > Documentation, guides, standards, and learning materials for Model Context Protocol and MCP server development.
 
 - [Model Context Protocol Specification](https://modelcontextprotocol.io/) — Official MCP specification
+- [nowork-studio/NotFair](https://github.com/nowork-studio/NotFair) - Open-source Claude Code agent skills for SEO, GEO, Google Ads, and Meta Ads; connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.
 
 ## Tutorials
 


### PR DESCRIPTION
Thanks for maintaining this list — it's a solid reference for anyone working in the MCP ecosystem.

I'd like to add [NotFair](https://github.com/nowork-studio/NotFair), an open-source set of Claude Code agent skills for marketing work (SEO, GEO, Google Ads, Meta Ads). It has ~2.9k stars and is MIT-licensed. The project connects Claude Code to live ad and analytics data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP — making it a real-world example of Claude Code skills consuming MCP servers in a production context.

I placed it in the **Resources** section since it demonstrates how MCP servers can be consumed by Claude Code agent skills, which felt like the closest fit for a practitioner-facing, MCP-connected toolkit. Happy to move it to a different section or trim the description if you'd prefer something shorter.