### PR TITLE
Add SandBase CLI to MCP gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Public test endpoints:
 - [lightconetech/mcp-gateway](https://github.com/lightconetech/mcp-gateway) 📇 - A gateway demo for MCP SSE Server
 - [mcpjungle/MCPJungle](https://github.com/mcpjungle/MCPJungle) 🌳 - Self-hosted MCP Registry and Proxy for ai agents
 - [multi-mcp](https://github.com/kfirtoledo/multi-mcp) 🐍 - A flexible and dynamic Multi-MCP Proxy Server that acts as a single MCP server while connecting to and routing between multiple backend MCP servers over STDIO or SSE. Deployable on Kubernetes by exposing a single port, and supports dynamic addition and removal of MCP servers at runtime.
+- [SandBase CLI](https://github.com/sandbaseai/cli) 📇 - Open-source local MCP bridge that lets 25 supported AI clients discover and run 2,000+ AI models.
 - [SecretiveShell/MCP-Bridge](https://github.com/SecretiveShell/MCP-Bridge) 🐍 – An openAI middleware proxy to use MCP in any existing openAI compatible client
 - [sparfenyuk/mcp-proxy](https://github.com/sparfenyuk/mcp-proxy) 🐍 – An MCP stdio to SSE transport gateway
 - [TBXark/mcp-proxy](https://github.com/TBXark/mcp-proxy) 🏎️ - An MCP proxy server that aggregates multiple MCP resource servers through a single HTTP server


### PR DESCRIPTION
## Summary

Adds [SandBase CLI](https://github.com/sandbaseai/cli) to **Utilities → Proxies and Gateways**.

SandBase CLI is an Apache-2.0 TypeScript CLI and local MCP bridge that lets 25 supported AI clients discover and run 2,000+ AI models.

## Validation

- Added one README entry in alphabetical order
- `git diff --check` passes
- `awesome-lint` reports only pre-existing issues on other lines; the new entry has no lint finding
- Canonical project link and current project facts used

## Disclosure

I am affiliated with SandBase.
