### PR TITLE
Add greenlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Public test endpoints:
 
 ### Development Tools
 
+- [ai-ward/greenlight](https://github.com/ai-ward/greenlight) 🐍 - Transparent stdio/HTTP proxy that logs every MCP message to JSONL, with a colorized live trace viewer and a stats command with a CI-usable exit code.
 - [Epistates/TurboMCPStudio](https://github.com/Epistates/TurboMCPStudio) 🦀 - Full Featured MCP Suite
 - [inercia/mcpshell](https://github.com/inercia/mcpshell) 🏎️ - Use shell scripts as MCP tools.
 - [ithena-one/ithena-cli](https://github.com/ithena-one/ithena-cli) 🏎️ - Wraps MCP commands to log interactions locally, facilitating debugging and interaction audits. Optional cloud.

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Public test endpoints:
 
 ### Development Tools
 
-- [ai-ward/greenlight](https://github.com/ai-ward/greenlight) 🐍 - Transparent stdio/HTTP proxy that logs every MCP message to JSONL, with a colorized live trace viewer and a stats command with a CI-usable exit code.
+- [bradsward/greenlight](https://github.com/bradsward/greenlight) 🐍 - Transparent stdio/HTTP proxy that logs every MCP message to JSONL, with a colorized live trace viewer and a stats command with a CI-usable exit code.
 - [Epistates/TurboMCPStudio](https://github.com/Epistates/TurboMCPStudio) 🦀 - Full Featured MCP Suite
 - [inercia/mcpshell](https://github.com/inercia/mcpshell) 🏎️ - Use shell scripts as MCP tools.
 - [ithena-one/ithena-cli](https://github.com/ithena-one/ithena-cli) 🏎️ - Wraps MCP commands to log interactions locally, facilitating debugging and interaction audits. Optional cloud.


### PR DESCRIPTION
Adds [greenlight](https://github.com/ai-ward/greenlight) under Development Tools.

Transparent proxy for MCP servers (stdio and Streamable HTTP) that logs every JSON-RPC message to a structured JSONL log, with a live colorized trace viewer (green/yellow/red by status) and a `stats` command that exits non-zero on failure, for CI use.

One line, alphabetically placed per the contributing guide.