### PR TITLE
Add MCP Host Canary to Testing Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [Epistates/TurboMCPStudio](https://github.com/Epistates/TurboMCPStudio) 🦀 - Full Featured MCP Suite, testing and debugging.
 - [1Utkarsh1/mcp-stdio-guard](https://github.com/1Utkarsh1/mcp-stdio-guard) 📇 - CLI and CI guard for MCP stdio servers that validates initialize handshakes, `tools/list`, stdout JSON-RPC hygiene, crashes, repeat runs, and risky stdout writes.
 - [mclenhard/mcp-evals](https://github.com/mclenhard/mcp-evals) 🤖 - Package and Github action for running evals. 
+- [sjh9714/mcp-host-canary](https://github.com/sjh9714/mcp-host-canary) 📇 - Creates disposable remote MCP test endpoints and privacy-safe receipts of the last protocol boundary observed from Claude, ChatGPT, Cursor, and other managed hosts.
 - [modelcontextprotocol/inspector](https://github.com/modelcontextprotocol/inspector) 📇 🎖️ - UI for testing MCP servers.
 - [wong2/mcp-cli](https://github.com/wong2/mcp-cli) 🤖 - Command line inspector for manual testing
 - [muppet-kit/inspector](https://github.com/muppet-dev/kit) - MCP Inspector with AI-assisted debugging and testing capabilities.


### PR DESCRIPTION
Adds MCP Host Canary to the Testing Tools section.

Disclosure: I maintain the project. It is a free, MIT-licensed TypeScript tool that creates disposable no-auth endpoints and records only allowlisted server-observed MCP boundaries. This PR changes one README line and makes no compatibility claims.