### PR TITLE
Add correctover-scan — security scanner CLI for MCP configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [loopwork-ai/Companion](https://github.com/loopwork-ai/Companion) - Companion is a utility for testing and debugging your MCP servers on macOS, iOS, and visionOS.
 - [garagon/aguara](https://github.com/garagon/aguara) 🏎️ - Static security scanner for MCP servers and AI agent skills. 173 detection rules, prompt injection, credential leaks, taint tracking. Scans configs and tool descriptions before deployment.
 - [greynewell/mcpbr](https://github.com/greynewell/mcpbr) 🐍 - Benchmark runner for evaluating MCP server performance and agentic capabilities.
+- [Correctover/correctover-scan](https://github.com/Correctover/correctover-scan) 📇 - Zero-config CLI security scanner for MCP configs across Claude Desktop, Cursor, VS Code, and generic mcp.json. Checks credential exposure, SSRF protection, auth and transport encryption, with JSON/SARIF output for CI. Runs via `npx correctover-scan`.
 - [realwigu/mcp-doctor](https://github.com/realwigu/mcp-doctor) 📇 - Zero-config CLI that auto-discovers MCP configs across Claude Code, Cursor, VS Code, Windsurf, and Claude Desktop. Tests connections via JSON-RPC handshake, audits for security issues, and benchmarks latency.
 - [markndg/mcp-probe](https://github.com/markndg/mcp-probe) 🦀 - Rust CLI that validates conformance, schema correctness, and capability negotiation against any MCP server.
 


### PR DESCRIPTION
Adds [correctover-scan](https://github.com/Correctover/correctover-scan) to **Testing Tools**, alongside other MCP security/audit CLIs (aguara, mcp-doctor).

What it is: a TypeScript npm CLI (`npx correctover-scan`, 📇 per the legend) that auto-discovers MCP configuration files (Claude Desktop, Cursor, VS Code, `.mcp/mcp.json`, …) and checks them for security issues — credential exposure, SSRF, missing auth/TLS, missing timeouts and audit logging — with findings mapped to OWASP AISVS and JSON/SARIF output for CI.

Why it fits: Testing Tools already lists static security scanners and config-audit CLIs for MCP (aguara, mcp-doctor); this is a config-security testing tool in the same category. Format follows the existing list style.

Disclosure: I maintain this project (MIT-licensed).